### PR TITLE
support using custom http client

### DIFF
--- a/cli/cmd/create.go
+++ b/cli/cmd/create.go
@@ -15,8 +15,10 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"strings"
 
@@ -45,7 +47,15 @@ func RunECreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	resp, err := connectors.NewClient(url).CreateConnector(config, sync)
+	client := connectors.NewClient(url)
+	if insecureSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = client.WithHTTPClient(&http.Client{Transport: tr})
+	}
+
+	resp, err := client.CreateConnector(config, sync)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/delete.go
+++ b/cli/cmd/delete.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"net/http"
+
 	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 	"github.com/spf13/cobra"
 )
@@ -37,7 +40,15 @@ func RunEDelete(cmd *cobra.Command, args []string) error {
 		Name: connector,
 	}
 
-	resp, err := connectors.NewClient(url).DeleteConnector(req, sync)
+	client := connectors.NewClient(url)
+	if insecureSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = client.WithHTTPClient(&http.Client{Transport: tr})
+	}
+
+	resp, err := client.DeleteConnector(req, sync)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/get.go
+++ b/cli/cmd/get.go
@@ -15,7 +15,9 @@
 package cmd
 
 import (
+	"crypto/tls"
 	"errors"
+	"net/http"
 
 	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 	"github.com/spf13/cobra"
@@ -69,6 +71,13 @@ func validateArgs() error {
 func getConnector() error {
 
 	client := connectors.NewClient(url)
+	if insecureSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = client.WithHTTPClient(&http.Client{Transport: tr})
+	}
+
 	req := connectors.ConnectorRequest{
 		Name: connector,
 	}

--- a/cli/cmd/pause.go
+++ b/cli/cmd/pause.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"net/http"
+
 	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +39,16 @@ func RunEPause(cmd *cobra.Command, args []string) error {
 	req := connectors.ConnectorRequest{
 		Name: connector,
 	}
-	resp, err := connectors.NewClient(url).PauseConnector(req, sync)
+
+	client := connectors.NewClient(url)
+	if insecureSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = client.WithHTTPClient(&http.Client{Transport: tr})
+	}
+
+	resp, err := client.PauseConnector(req, sync)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/resume.go
+++ b/cli/cmd/resume.go
@@ -15,6 +15,9 @@
 package cmd
 
 import (
+	"crypto/tls"
+	"net/http"
+
 	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +39,15 @@ func RunEResume(cmd *cobra.Command, args []string) error {
 	req := connectors.ConnectorRequest{
 		Name: connector,
 	}
-	resp, err := connectors.NewClient(url).ResumeConnector(req, sync)
+
+	client := connectors.NewClient(url)
+	if insecureSkipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = client.WithHTTPClient(&http.Client{Transport: tr})
+	}
+	resp, err := client.ResumeConnector(req, sync)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -25,14 +25,15 @@ import (
 
 var cfgFile string
 var (
-	url          string
-	connector    string
-	file         string
-	configString string
-	sync         bool
-	status       bool
-	config       bool
-	tasks        bool
+	url                string
+	insecureSkipVerify bool
+	connector          string
+	file               string
+	configString       string
+	sync               bool
+	status             bool
+	config             bool
+	tasks              bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -67,6 +68,7 @@ func init() {
 	// will be global for your application.
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.cli.yaml)")
 	RootCmd.PersistentFlags().StringVarP(&url, "url", "u", "http://localhost:8083", "kafka connect URL")
+	RootCmd.PersistentFlags().BoolVarP(&insecureSkipVerify, "insecure-skip-verify", "", false, "ssl insecure skip verify")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/lib/Gopkg.lock
+++ b/lib/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -22,6 +28,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b750880cdc8ce044e6f9bf3b331d8a392471c328107b8c3d42e3e11022d76858"
+  inputs-digest = "1d20f5541af61ea899f38e2f88d19952d2c2dd76ff6de1f0c772966f55f52896"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/lib/connectors/client.go
+++ b/lib/connectors/client.go
@@ -10,7 +10,8 @@ import (
 
 //Client represents the kafka connect access configuration
 type Client struct {
-	URL string
+	URL    string
+	client *http.Client
 }
 
 //ErrorResponse is generic error returned by kafka connect
@@ -25,7 +26,13 @@ func (err ErrorResponse) Error() string {
 
 //NewClient generates a new client
 func NewClient(url string) Client {
-	return Client{URL: url}
+	return Client{URL: url, client: http.DefaultClient}
+}
+
+// WithHTTPClient overrides default http client
+func (c Client) WithHTTPClient(client *http.Client) Client {
+	c.client = client
+	return c
 }
 
 //Request handles an HTTP Get request to the client
@@ -52,7 +59,7 @@ func (c Client) Request(method string, endpoint string, request interface{}, res
 		return 0, err
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := c.client.Do(req)
 	if err != nil {
 		return 0, err
 	}

--- a/lib/connectors/connectors.go
+++ b/lib/connectors/connectors.go
@@ -299,7 +299,7 @@ func (c Client) IsUpToDate(connector string, config map[string]string) (bool, er
 		return false, nil
 	}
 	if configResp.Code >= 400 {
-		return false, errors.New(fmt.Sprintf("status code: %d", configResp.Code))
+		return false, fmt.Errorf("status code: %d", configResp.Code)
 	}
 
 	if len(configResp.Config) != len(config) {


### PR DESCRIPTION
Added support to http client override. Common use case is skip ssl verify.

Existing code doesn't need to be changed.