### PR TITLE
Add support for basic auth username and password

### DIFF
--- a/cli/cmd/helper.go
+++ b/cli/cmd/helper.go
@@ -4,8 +4,9 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 	"log"
+
+	"github.com/ricardo-ch/go-kafka-connect/lib/connectors"
 )
 
 func printResponse(response interface{}) error {
@@ -24,6 +25,9 @@ func getClient() connectors.HighLevelClient {
 	}
 	if SSLInsecure {
 		client.SetInsecureSSL()
+	}
+	if basicAuthUsername != "" && basicAuthPassword != "" {
+		client.SetBasicAuth(basicAuthUsername, basicAuthPassword)
 	}
 	if len(SSLClientCertificate) > 0 && len(SSLClientPrivateKey) > 0 {
 		cert, err := tls.LoadX509KeyPair(SSLClientCertificate, SSLClientPrivateKey)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -35,6 +35,8 @@ var (
 	parallel             int
 	SSLClientCertificate string
 	SSLClientPrivateKey  string
+	basicAuthUsername    string
+	basicAuthPassword    string
 )
 
 var RootCmd = &cobra.Command{
@@ -60,4 +62,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&SSLInsecure, "insecure-skip-verify", "i", false, `skip SSL/TLS verification`)
 	RootCmd.PersistentFlags().StringVarP(&SSLClientCertificate, "ssl-client-certificate", "C", "", `path to client certificate, must contain PEM encoded data`)
 	RootCmd.PersistentFlags().StringVarP(&SSLClientPrivateKey, "ssl-client-key", "K", "", `path to client private key`)
+	RootCmd.PersistentFlags().StringVarP(&basicAuthUsername, "username", "U", "", `HTTP Basic Auth username`)
+	RootCmd.PersistentFlags().StringVarP(&basicAuthPassword, "password", "P", "", `HTTP Basic Auth password`)
 }

--- a/lib/connectors/base_client.go
+++ b/lib/connectors/base_client.go
@@ -3,10 +3,11 @@ package connectors
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/pkg/errors"
-	"gopkg.in/resty.v1"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
+	"gopkg.in/resty.v1"
 )
 
 // BaseClient implement the kafka-connect contract as a client
@@ -29,6 +30,7 @@ type BaseClient interface {
 	SetInsecureSSL()
 	SetDebug()
 	SetClientCertificates(certs ...tls.Certificate)
+	SetBasicAuth(username string, password string)
 }
 
 type baseClient struct {
@@ -45,6 +47,10 @@ func (c *baseClient) SetDebug() {
 
 func (c *baseClient) SetClientCertificates(certs ...tls.Certificate) {
 	c.restClient.SetCertificates(certs...)
+}
+
+func (c *baseClient) SetBasicAuth(username string, password string) {
+	c.restClient.SetBasicAuth(username, password)
 }
 
 //ErrorResponse is generic error returned by kafka connect

--- a/lib/connectors/highlevel_client.go
+++ b/lib/connectors/highlevel_client.go
@@ -35,6 +35,7 @@ type HighLevelClient interface {
 	SetDebug()
 	SetClientCertificates(certs ...tls.Certificate)
 	SetParallelism(value int)
+	SetBasicAuth(username string, password string)
 }
 
 type highLevelClient struct {
@@ -63,6 +64,10 @@ func (c *highLevelClient) SetDebug() {
 
 func (c *highLevelClient) SetClientCertificates(certs ...tls.Certificate) {
 	c.client.SetClientCertificates(certs...)
+}
+
+func (c *highLevelClient) SetBasicAuth(username string, password string) {
+	c.client.SetBasicAuth(username, password)
 }
 
 //GetAll gets the list of all active connectors

--- a/lib/connectors/mock_base_client.go
+++ b/lib/connectors/mock_base_client.go
@@ -264,6 +264,11 @@ func (_m *MockBaseClient) ResumeConnector(req ConnectorRequest) (EmptyResponse, 
 	return r0, r1
 }
 
+// SetBasicAuth provides a mock function with given fields: username, password
+func (_m *MockBaseClient) SetBasicAuth(username string, password string) {
+	_m.Called(username, password)
+}
+
 // SetClientCertificates provides a mock function with given fields: certs
 func (_m *MockBaseClient) SetClientCertificates(certs ...tls.Certificate) {
 	_va := make([]interface{}, len(certs))

--- a/lib/connectors/mock_high_level_client.go
+++ b/lib/connectors/mock_high_level_client.go
@@ -313,6 +313,11 @@ func (_m *MockHighLevelClient) ResumeConnector(req ConnectorRequest, sync bool) 
 	return r0, r1
 }
 
+// SetBasicAuth provides a mock function with given fields: username, password
+func (_m *MockHighLevelClient) SetBasicAuth(username string, password string) {
+	_m.Called(username, password)
+}
+
 // SetClientCertificates provides a mock function with given fields: certs
 func (_m *MockHighLevelClient) SetClientCertificates(certs ...tls.Certificate) {
 	_va := make([]interface{}, len(certs))


### PR DESCRIPTION
Kafka Connect has a HTTP basic auth extension (https://docs.confluent.io/current/security/basic-auth.html#basic-auth-kconnect). Alternatively, fronting Kafka Connect with an authenticating reverse proxy is a common solution to protect the REST API.

This pull request is a means to an end to ultimately add basic auth support to https://github.com/Mongey/terraform-provider-kafka-connect.