### PR TITLE
Add the ability to specify additional custom HTTP headers

### DIFF
--- a/cli/cmd/headers_flag.go
+++ b/cli/cmd/headers_flag.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CustomHeader represents a single HTTP header name/value pair to be attached to
+// outbound HTTP requests against the Connect REST API.
+type CustomHeader struct {
+	Name  string
+	Value string
+}
+
+func (h *CustomHeader) Parse(raw string) error {
+	parts := strings.Split(raw, ":")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid header flag format, expected '<name>:<value>'")
+	}
+
+	h.Name = parts[0]
+	h.Value = strings.TrimLeft(parts[1], " ")
+	return nil
+}
+
+func (h *CustomHeader) String() string {
+	return fmt.Sprintf("%s: %s", h.Name, h.Value)
+}
+
+// HeadersFlag implements the Value interface from pflag in order to support parsing
+// flag values of the form '<name>:<value>' directly into a list of CustomHeader
+// instances.
+type HeadersFlag struct {
+	Headers []CustomHeader
+}
+
+func (h *HeadersFlag) String() string {
+	var pairs []string
+	for _, header := range h.Headers {
+		pairs = append(pairs, header.String())
+	}
+	return strings.Join(pairs, ", ")
+}
+
+func (h *HeadersFlag) Set(raw string) error {
+	header := CustomHeader{}
+	if err := header.Parse(raw); err != nil {
+		return err
+	}
+	h.Headers = append(h.Headers, header)
+	return nil
+}
+
+func (h *HeadersFlag) Type() string {
+	return "<name>:<value>"
+}

--- a/cli/cmd/helper.go
+++ b/cli/cmd/helper.go
@@ -37,5 +37,11 @@ func getClient() connectors.HighLevelClient {
 			client.SetClientCertificates(cert)
 		}
 	}
+	if len(extraHeaders.Headers) > 0 {
+		for _, header := range extraHeaders.Headers {
+			client.SetHeader(header.Name, header.Value)
+		}
+	}
+
 	return client
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,9 +16,8 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var (
@@ -37,6 +36,7 @@ var (
 	SSLClientPrivateKey  string
 	basicAuthUsername    string
 	basicAuthPassword    string
+	extraHeaders         HeadersFlag
 )
 
 var RootCmd = &cobra.Command{
@@ -64,4 +64,5 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&SSLClientPrivateKey, "ssl-client-key", "K", "", `path to client private key`)
 	RootCmd.PersistentFlags().StringVarP(&basicAuthUsername, "username", "U", "", `HTTP Basic Auth username`)
 	RootCmd.PersistentFlags().StringVarP(&basicAuthPassword, "password", "P", "", `HTTP Basic Auth password`)
+	RootCmd.PersistentFlags().VarP(&extraHeaders, "header", "H", "extra HTTP headers to attach to REST API requests")
 }

--- a/lib/connectors/base_client.go
+++ b/lib/connectors/base_client.go
@@ -31,6 +31,7 @@ type BaseClient interface {
 	SetDebug()
 	SetClientCertificates(certs ...tls.Certificate)
 	SetBasicAuth(username string, password string)
+	SetHeader(name string, value string)
 }
 
 type baseClient struct {
@@ -51,6 +52,10 @@ func (c *baseClient) SetClientCertificates(certs ...tls.Certificate) {
 
 func (c *baseClient) SetBasicAuth(username string, password string) {
 	c.restClient.SetBasicAuth(username, password)
+}
+
+func (c *baseClient) SetHeader(name string, value string) {
+	c.restClient.SetHeader(name, value)
 }
 
 //ErrorResponse is generic error returned by kafka connect

--- a/lib/connectors/highlevel_client.go
+++ b/lib/connectors/highlevel_client.go
@@ -36,6 +36,7 @@ type HighLevelClient interface {
 	SetClientCertificates(certs ...tls.Certificate)
 	SetParallelism(value int)
 	SetBasicAuth(username string, password string)
+	SetHeader(name string, value string)
 }
 
 type highLevelClient struct {
@@ -68,6 +69,10 @@ func (c *highLevelClient) SetClientCertificates(certs ...tls.Certificate) {
 
 func (c *highLevelClient) SetBasicAuth(username string, password string) {
 	c.client.SetBasicAuth(username, password)
+}
+
+func (c *highLevelClient) SetHeader(name string, value string) {
+	c.client.SetHeader(name, value)
 }
 
 //GetAll gets the list of all active connectors

--- a/lib/connectors/mock_base_client.go
+++ b/lib/connectors/mock_base_client.go
@@ -269,6 +269,10 @@ func (_m *MockBaseClient) SetBasicAuth(username string, password string) {
 	_m.Called(username, password)
 }
 
+func (_m *MockBaseClient) SetHeader(name string, value string) {
+	_m.Called(name, value)
+}
+
 // SetClientCertificates provides a mock function with given fields: certs
 func (_m *MockBaseClient) SetClientCertificates(certs ...tls.Certificate) {
 	_va := make([]interface{}, len(certs))


### PR DESCRIPTION
This change adds the ability to attach additional HTTP headers to all outbound HTTP requests against the Kafka Connect REST API.

The motivating use case here is to support additional types of authentication beyond just HTTP basic auth, as requested in https://github.com/ricardo-ch/go-kafka-connect/issues/39.

More specifically, my hope is to be able to consume this functionality within https://github.com/Mongey/terraform-provider-kafka-connect, which is a client of this library.