### PR TITLE
Throw errors for invalid json config files

### DIFF
--- a/cli/cmd/create_test.go
+++ b/cli/cmd/create_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/ricardo-ch/go-kafka-connect/v3/lib/connectors"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getCreateCmdConfig_Invalid_Path(t *testing.T) {
+	configs, err := getConfigFromFolder("missingFolder")
+
+	assert.NotNil(t, err)
+	assert.Zero(t, configs)
+}
+
+func Test_getConfigFromFolder_OK(t *testing.T) {
+	expected := []connectors.CreateConnectorRequest{
+		{
+			ConnectorRequest: connectors.ConnectorRequest{
+				Name: "test-connector",
+			},
+			Config: map[string]interface{}{
+				"config-entry": "some-value",
+			},
+		},
+		{
+			ConnectorRequest: connectors.ConnectorRequest{
+				Name: "test-connector-2",
+			},
+			Config: map[string]interface{}{
+				"config-entry-2": "some-value-2",
+			},
+		},
+	}
+
+	_ = os.Mkdir("test", os.ModePerm)
+	defer os.RemoveAll("test")
+
+	j1, _ := json.MarshalIndent(expected[0], "", "")
+	j2, _ := json.MarshalIndent(expected[1], "", "")
+
+	_ = ioutil.WriteFile("test/test1.json", j1, os.ModePerm)
+	_ = ioutil.WriteFile("test/test2.json", j2, os.ModePerm)
+
+	actual, err := getConfigFromFolder("test")
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func Test_getConfigFromFolder_Invalid_JSON(t *testing.T) {
+	unsupported := `{"some-key": "some-value"}`
+
+	_ = os.Mkdir("test", os.ModePerm)
+	defer os.RemoveAll("test")
+
+	j1, _ := json.MarshalIndent(unsupported, "", "")
+
+	_ = ioutil.WriteFile("test/test1.json", j1, os.ModePerm)
+
+	actual, err := getConfigFromFolder("test")
+
+	assert.NotNil(t, err)
+	assert.Equal(t, []connectors.CreateConnectorRequest{}, actual)
+}
+
+func Test_getConfigFromFolder_Missing_Folder(t *testing.T) {
+	configs, err := getConfigFromFolder("test")
+
+	assert.NotNil(t, err)
+	assert.Zero(t, configs)
+}
+
+func Test_getConfigFromFolder_Not_A_Folder(t *testing.T) {
+	// Create a file instead of a folder
+	_, _ = os.Create("test")
+	defer os.Remove("test")
+
+	configs, err := getConfigFromFolder("test")
+
+	assert.NotNil(t, err)
+	assert.Zero(t, configs)
+}
+
+func Test_getConfigFromFile_OK(t *testing.T) {
+	expected := connectors.CreateConnectorRequest{
+		ConnectorRequest: connectors.ConnectorRequest{
+			Name: "test-connector",
+		},
+		Config: map[string]interface{}{
+			"config-entry": "some-value",
+		},
+	}
+
+	j, _ := json.MarshalIndent(expected, "", "")
+
+	_ = ioutil.WriteFile("test.json", j, 0644)
+	defer os.Remove("test.json")
+
+	actual, err := getConfigFromFile("test.json")
+
+	assert.Nil(t, err)
+	assert.Equal(t, expected, actual)
+
+}
+
+func Test_getConfigFromFile_Invalid_JSON(t *testing.T) {
+	unsupported := `{"some-key": "some-value"}`
+
+	j, _ := json.MarshalIndent(unsupported, "", "")
+
+	_ = ioutil.WriteFile("test.json", j, os.ModePerm)
+	defer os.Remove("test.json")
+
+	actual, err := getConfigFromFile("test.json")
+
+	assert.NotNil(t, err)
+	assert.Zero(t, actual)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -16,8 +16,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var (


### PR DESCRIPTION
The deploy command would consider any file it could not parse as a non-config file, log an info and move on with the deployment.
In the event of non-config files it makes sense, but this also hides potential formatting issues of actual config files that were meant to be deployed.

This PR modifies the behaviour in case an invalid config file is met: an error is now raised and the deployment will be aborted.
Finer-grained files selection could be added in the future but it is considered out of scope for the moment.

I also took this opportunity to properly unit test the create command.
More tests for the other commands will come in the future.