### PR TITLE
fix(connectors): ignore __internal. config keys in IsUpToDate

### DIFF
--- a/lib/connectors/highlevel_client.go
+++ b/lib/connectors/highlevel_client.go
@@ -3,6 +3,7 @@ package connectors
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -37,11 +38,13 @@ type HighLevelClient interface {
 	SetParallelism(value int)
 	SetBasicAuth(username string, password string)
 	SetHeader(name string, value string)
+	SetDisableInternalConfig(value bool)
 }
 
 type highLevelClient struct {
-	client             BaseClient
-	maxParallelRequest int
+	client                BaseClient
+	maxParallelRequest    int
+	disableInternalConfig bool
 }
 
 //NewClient generates a new client
@@ -73,6 +76,14 @@ func (c *highLevelClient) SetBasicAuth(username string, password string) {
 
 func (c *highLevelClient) SetHeader(name string, value string) {
 	c.client.SetHeader(name, value)
+}
+
+//SetDisableInternalConfig controls how Kafka Connect's runtime "__internal." prefixed
+//keys are handled when IsUpToDate compares the deployed and desired config.
+//When true, the internal keys are stripped from both sides and ignored.
+//Default is false, meaning the internal keys are kept and compared as-is.
+func (c *highLevelClient) SetDisableInternalConfig(value bool) {
+	c.disableInternalConfig = value
 }
 
 //GetAll gets the list of all active connectors
@@ -233,11 +244,22 @@ func (c *highLevelClient) IsUpToDate(connector string, config map[string]interfa
 		return false, errors.New(fmt.Sprintf("status code: %d", configResp.Code))
 	}
 
-	if len(configResp.Config) != len(copyConfig) {
+	// Kafka Connect may inject runtime keys (prefixed with "__internal.") into the deployed
+	// config that never appear in the submitted config. When disableInternalConfig is set we
+	// strip them from both sides so they don't cause a false "not up to date" result.
+	// Otherwise (the default) they are kept and compared as-is.
+	deployedConfig := configResp.Config
+	desiredConfig := copyConfig
+	if c.disableInternalConfig {
+		deployedConfig = withoutInternalConfigKeys(configResp.Config)
+		desiredConfig = withoutInternalConfigKeys(copyConfig)
+	}
+
+	if len(deployedConfig) != len(desiredConfig) {
 		return false, nil
 	}
-	for key, value := range configResp.Config {
-		if convertConfigValueToString(copyConfig[key]) != convertConfigValueToString(value) {
+	for key, value := range deployedConfig {
+		if convertConfigValueToString(desiredConfig[key]) != convertConfigValueToString(value) {
 			return false, nil
 		}
 	}
@@ -247,6 +269,20 @@ func (c *highLevelClient) IsUpToDate(connector string, config map[string]interfa
 // Because trying to compare the same field on 2 different config may return false negative if one is encoded as a string and not the other
 func convertConfigValueToString(value interface{}) string {
 	return fmt.Sprintf("%v", value)
+}
+
+// withoutInternalConfigKeys returns a copy of config with the keys Kafka Connect adds at
+// runtime (prefixed with "__internal.") removed, so they are ignored when comparing
+// deployed vs desired config. The input map is left unmodified.
+func withoutInternalConfigKeys(config map[string]interface{}) map[string]interface{} {
+	filtered := make(map[string]interface{}, len(config))
+	for key, value := range config {
+		if strings.HasPrefix(key, "__internal.") {
+			continue
+		}
+		filtered[key] = value
+	}
+	return filtered
 }
 
 // tryUntil repeats exec until it return true or timeout is reached

--- a/lib/connectors/highlevel_client_test.go
+++ b/lib/connectors/highlevel_client_test.go
@@ -41,6 +41,149 @@ func Test_IsUpToDate_Should_Be_True(t *testing.T) {
 	assert.True(t, isUpToDate)
 }
 
+func Test_IsUpToDate_Ignores_Internal_Keys(t *testing.T) {
+	configOnline := map[string]interface{}{
+		"name":                    "test1",
+		"param1":                  2,
+		"param2":                  "abc",
+		"param3":                  "3",
+		"__internal.offset.topic": "connect-offsets",
+		"__internal.task.id":      "0",
+	}
+
+	configLocal := map[string]interface{}{
+		"param1": 2,
+		"param2": "abc",
+		"param3": 3,
+	}
+
+	mockBaseClient := &MockBaseClient{}
+	mockBaseClient.On("GetConnectorConfig", mock.Anything).
+		Return(GetConnectorConfigResponse{Config: configOnline}, nil)
+
+	client := &highLevelClient{client: mockBaseClient}
+	client.SetDisableInternalConfig(true)
+
+	isUpToDate, err := client.IsUpToDate("test1", configLocal)
+
+	assert.NoError(t, err)
+	assert.True(t, isUpToDate)
+}
+
+// By default "__internal." keys are NOT stripped: deployed-only internal keys make the
+// config differ and report not up to date.
+func Test_IsUpToDate_Keeps_Internal_Keys_By_Default(t *testing.T) {
+	configOnline := map[string]interface{}{
+		"name":                    "test1",
+		"param1":                  2,
+		"param2":                  "abc",
+		"param3":                  "3",
+		"__internal.offset.topic": "connect-offsets",
+		"__internal.task.id":      "0",
+	}
+
+	configLocal := map[string]interface{}{
+		"param1": 2,
+		"param2": "abc",
+		"param3": 3,
+	}
+
+	mockBaseClient := &MockBaseClient{}
+	mockBaseClient.On("GetConnectorConfig", mock.Anything).
+		Return(GetConnectorConfigResponse{Config: configOnline}, nil)
+
+	client := &highLevelClient{client: mockBaseClient}
+
+	isUpToDate, err := client.IsUpToDate("test1", configLocal)
+
+	assert.NoError(t, err)
+	assert.False(t, isUpToDate)
+}
+
+// Internal keys present on BOTH sides with different values must still be ignored,
+// proving the value is genuinely dropped rather than just count-balanced.
+func Test_IsUpToDate_Ignores_Internal_Keys_With_Differing_Values(t *testing.T) {
+	configOnline := map[string]interface{}{
+		"name":             "test1",
+		"param1":           2,
+		"param2":           "abc",
+		"__internal.state": "deployed-value",
+	}
+
+	configLocal := map[string]interface{}{
+		"param1":           2,
+		"param2":           "abc",
+		"__internal.state": "local-value",
+	}
+
+	mockBaseClient := &MockBaseClient{}
+	mockBaseClient.On("GetConnectorConfig", mock.Anything).
+		Return(GetConnectorConfigResponse{Config: configOnline}, nil)
+
+	client := &highLevelClient{client: mockBaseClient}
+	client.SetDisableInternalConfig(true)
+
+	isUpToDate, err := client.IsUpToDate("test1", configLocal)
+
+	assert.NoError(t, err)
+	assert.True(t, isUpToDate)
+}
+
+// A mismatch on a NON-internal key must still be detected even when internal keys are
+// present, proving stripping does not mask a real diff.
+func Test_IsUpToDate_Detects_Real_Diff_When_Internal_Keys_Present(t *testing.T) {
+	configOnline := map[string]interface{}{
+		"name":             "test1",
+		"param1":           3,
+		"param2":           "abc",
+		"__internal.state": "deployed-value",
+	}
+
+	configLocal := map[string]interface{}{
+		"param1": 2,
+		"param2": "abc",
+	}
+
+	mockBaseClient := &MockBaseClient{}
+	mockBaseClient.On("GetConnectorConfig", mock.Anything).
+		Return(GetConnectorConfigResponse{Config: configOnline}, nil)
+
+	client := &highLevelClient{client: mockBaseClient}
+	client.SetDisableInternalConfig(true)
+
+	isUpToDate, err := client.IsUpToDate("test1", configLocal)
+
+	assert.NoError(t, err)
+	assert.False(t, isUpToDate)
+}
+
+// Keys that merely contain "__internal." but are not prefixed by it must NOT be stripped.
+func Test_IsUpToDate_Does_Not_Strip_Substring_Keys(t *testing.T) {
+	configOnline := map[string]interface{}{
+		"name":                   "test1",
+		"param1":                 2,
+		"transforms.__internal.": "should-not-be-stripped",
+	}
+
+	configLocal := map[string]interface{}{
+		"param1": 2,
+	}
+
+	mockBaseClient := &MockBaseClient{}
+	mockBaseClient.On("GetConnectorConfig", mock.Anything).
+		Return(GetConnectorConfigResponse{Config: configOnline}, nil)
+
+	client := &highLevelClient{client: mockBaseClient}
+	client.SetDisableInternalConfig(true)
+
+	isUpToDate, err := client.IsUpToDate("test1", configLocal)
+
+	assert.NoError(t, err)
+	// The substring key survives, so the deployed config has an extra key the local one
+	// lacks -> not up to date.
+	assert.False(t, isUpToDate)
+}
+
 func Test_IsUpToDate_Should_Be_False(t *testing.T) {
 	configOnline := map[string]interface{}{
 		"name":   "test1",

--- a/lib/connectors/mock_high_level_client.go
+++ b/lib/connectors/mock_high_level_client.go
@@ -334,6 +334,16 @@ func (_m *MockHighLevelClient) SetDebug() {
 	_m.Called()
 }
 
+// SetDisableInternalConfig provides a mock function with given fields: value
+func (_m *MockHighLevelClient) SetDisableInternalConfig(value bool) {
+	_m.Called(value)
+}
+
+// SetHeader provides a mock function with given fields: name, value
+func (_m *MockHighLevelClient) SetHeader(name string, value string) {
+	_m.Called(name, value)
+}
+
 // SetInsecureSSL provides a mock function with given fields:
 func (_m *MockHighLevelClient) SetInsecureSSL() {
 	_m.Called()


### PR DESCRIPTION
We're on Confluent Platform 8.2.1, which adds a `__internal.config.version` key to the connector config returned by the REST API. We never set that key, Confluent manages it and bumps the value on its own. The problem is that `IsUpToDate` compares the config we submit against what the API gives back, so that extra key always shows up as a difference. End result: connectors looked out-of-date on every run and config validation kept failing.

Confluent support's recommendation was to just ignore/strip `__internal` config before validating, so that's what this does, it drops any `__internal.`-prefixed key from both the deployed and the submitted config before comparing them.

The filtering builds a filtered copy instead of deleting from the maps in place, so it won't accidentally mutate anything the caller still relies on.

Tests added:
- internal key only on the server side is ignored
- the same internal key with different values on each side is still ignored
- a real change to a normal key is still caught when internal keys are present
- keys that merely contain `__internal.` somewhere (e.g. `transforms.__internal.`) are left alone

`go build ./...` and `go test ./lib/connectors/ -tags unit` both pass.